### PR TITLE
BUGFIX for EndroidQrCodeExtension::createBuilderDefinition

### DIFF
--- a/src/DependencyInjection/EndroidQrCodeExtension.php
+++ b/src/DependencyInjection/EndroidQrCodeExtension.php
@@ -77,11 +77,11 @@ final class EndroidQrCodeExtension extends Extension
                     $arguments[$name] = new Definition(Color::class, $value);
                     break;
                 case 'labelFontPath':
-                    $labelFontSize = $builderConfig['labelFontSize'] ?? 16;
+                    $labelFontSize = $builderConfig['label_font_size'] ?? 16;
                     $arguments['labelFont'] = new Definition(Font::class, [$value, $labelFontSize]);
                     break;
                 case 'labelFontSize':
-                    $labelFontPath = $builderConfig['labelFontPath'] ?? (new OpenSans())->getPath();
+                    $labelFontPath = $builderConfig['label_font_path'] ?? (new OpenSans())->getPath();
                     $arguments['labelFont'] = new Definition(Font::class, [$labelFontPath, $value]);
                     break;
                 case 'labelAlignment':


### PR DESCRIPTION
LabelFontSize or labelFontPath are not taken from Configuration if both values are defined in config.
Reason: Keys in array $builderConfig are snake_case not camelCase.

If both values are defined in the configuration, the one defined first was overwritten by the default value.