### PR TITLE
chore: update for Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
         "php": "^8.2",
         "endroid/installer": "^1.2.2",
         "endroid/qr-code": "^6.0.1",
-        "symfony/framework-bundle": "^5.4||^6.4||^7.0",
-        "symfony/twig-bundle": "^5.4||^6.4||^7.0",
-        "symfony/yaml": "^5.4||^6.4||^7.0"
+        "symfony/framework-bundle": "^5.4||^6.4||^7.0||^8.0",
+        "symfony/twig-bundle": "^5.4||^6.4||^7.0||^8.0",
+        "symfony/yaml": "^5.4||^6.4||^7.0||^8.0"
     },
     "require-dev": {
         "endroid/quality": "dev-main"


### PR DESCRIPTION
* https://symfony.com/blog/symfony-8-0-0-beta1-released

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Symfony component version constraints to support version 8.0 for framework-bundle, twig-bundle, and yaml packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->